### PR TITLE
API response parsing fix

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -533,7 +533,8 @@ class StagingOrchestrator:
                             return
 
                         data = await response.json()
-                        nodes = data.get("data", [])
+                        # KernelCI API returns nodes in "items" array, not "data"
+                        nodes = data.get("items", [])
 
                         # Look for a node with submitter: "service:pipeline" and matching tree
                         for node in nodes:


### PR DESCRIPTION
Changed from data.get("data", []) to data.get("items", []) to correctly extract the checkout nodes.